### PR TITLE
fix firefox-host.json path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -124,7 +124,7 @@ if [ "$BROWSER_NAME" == "Chrome" ] || \
   mkdir -p "$TARGET_DIR"/../policies/managed/
   cp "$DIR/chrome/policy.json" "$TARGET_DIR"/../policies/managed/"$APP_NAME.json"
 else
-  cp "$DIR/firefox/host.json" "$TARGET_DIR/$APP_NAME.json"
+  cp "$DIR/firefox-host.json" "$TARGET_DIR/$APP_NAME.json"
 fi
 
 # Replace path to host


### PR DESCRIPTION
    17:26:52 mcnesium@mcobst ~/Applications/Browserpass$ ./install.sh

    Select your browser:
    ====================
    1) Chrome
    2) Chromium
    3) Firefox
    4) Vivaldi
    1-4: 3

    Installing Firefox host config
    cp: /Users/mcnesium/Applications/Browserpass/firefox/host.json: No such file or directory
    17:27:26 mcnesium@mcobst ~/Applications/Browserpass$ subl install.sh

…changing the slash to a dash…

    17:27:35 mcnesium@mcobst ~/Applications/Browserpass$ ./install.sh

    Select your browser:
    ====================
    1) Chrome
    2) Chromium
    3) Firefox
    4) Vivaldi
    1-4: 3

    Installing Firefox host config
    Native messaging host for Firefox has been installed to /Users/mcnesium/Library/Application Support/Mozilla/NativeMessagingHosts.